### PR TITLE
Backport changes for Xcode 14.3 compatibility

### DIFF
--- a/Samples/iOS-Swift/PerformanceBenchmarks/SentryProcessInfo.m
+++ b/Samples/iOS-Swift/PerformanceBenchmarks/SentryProcessInfo.m
@@ -4,7 +4,7 @@
 #import <unistd.h>
 
 BOOL
-isDebugging()
+isDebugging(void)
 {
     struct kinfo_proc info;
 
@@ -29,7 +29,7 @@ isDebugging()
 }
 
 BOOL
-isSimulator()
+isSimulator(void)
 {
     NSOperatingSystemVersion ios9 = { 9, 0, 0 };
     NSProcessInfo *processInfo = [NSProcessInfo processInfo];

--- a/Sources/Sentry/SentrySwizzle.m
+++ b/Sources/Sentry/SentrySwizzle.m
@@ -112,7 +112,7 @@ swizzle(Class classToSwizzle, SEL selector, SentrySwizzleImpFactoryBlock factory
 }
 
 static NSMutableDictionary<NSValue *, NSMutableSet<Class> *> *
-swizzledClassesDictionary()
+swizzledClassesDictionary(void)
 {
     static NSMutableDictionary *swizzledClasses;
     static dispatch_once_t onceToken;

--- a/Sources/Sentry/SentrySysctl.m
+++ b/Sources/Sentry/SentrySysctl.m
@@ -19,7 +19,7 @@ static NSDate *runtimeInit = nil;
  * when enabling the address sanitizer.
  */
 __used __attribute__((constructor(60000))) static void
-sentryModuleInitializationHook()
+sentryModuleInitializationHook(void)
 {
     moduleInitializationTimestamp = [NSDate date];
 }

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor.c
@@ -195,7 +195,7 @@ sentrycrashcm_setActiveMonitors(SentryCrashMonitorType monitorTypes)
 }
 
 SentryCrashMonitorType
-sentrycrashcm_getActiveMonitors()
+sentrycrashcm_getActiveMonitors(void)
 {
     return g_activeMonitors;
 }

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_AppState.c
@@ -189,7 +189,7 @@ addJSONData(const char *const data, const int length, void *const userData)
 // ============================================================================
 
 static double
-getCurentTime()
+getCurentTime(void)
 {
     struct timeval tv;
     gettimeofday(&tv, NULL);
@@ -345,7 +345,7 @@ sentrycrashstate_initialize(const char *const stateFilePath)
 }
 
 bool
-sentrycrashstate_reset()
+sentrycrashstate_reset(void)
 {
     if (g_isEnabled) {
         g_state.sessionsSinceLaunch = 1;
@@ -459,7 +459,7 @@ setEnabled(bool isEnabled)
 }
 
 static bool
-isEnabled()
+isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -486,7 +486,7 @@ addContextualInfoToEvent(SentryCrash_MonitorContext *eventContext)
 }
 
 SentryCrashMonitorAPI *
-sentrycrashcm_appstate_getAPI()
+sentrycrashcm_appstate_getAPI(void)
 {
     static SentryCrashMonitorAPI api = { .setEnabled = setEnabled,
         .isEnabled = isEnabled,

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_MachException.c
@@ -385,7 +385,7 @@ handleExceptions(void *const userData)
 // ============================================================================
 
 static void
-uninstallExceptionHandler()
+uninstallExceptionHandler(void)
 {
     SentryCrashLOG_DEBUG("Uninstalling mach exception handler.");
 
@@ -422,7 +422,7 @@ uninstallExceptionHandler()
 }
 
 static bool
-installExceptionHandler()
+installExceptionHandler(void)
 {
     SentryCrashLOG_DEBUG("Installing mach exception handler.");
 
@@ -522,7 +522,7 @@ setEnabled(bool isEnabled)
 }
 
 static bool
-isEnabled()
+isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -540,7 +540,7 @@ addContextualInfoToEvent(struct SentryCrash_MonitorContext *eventContext)
 #endif
 
 SentryCrashMonitorAPI *
-sentrycrashcm_machexception_getAPI()
+sentrycrashcm_machexception_getAPI(void)
 {
     static SentryCrashMonitorAPI api = {
 #if SentryCrashCRASH_HAS_MACH

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_NSException.m
@@ -149,13 +149,13 @@ setEnabled(bool isEnabled)
 }
 
 static bool
-isEnabled()
+isEnabled(void)
 {
     return g_isEnabled;
 }
 
 SentryCrashMonitorAPI *
-sentrycrashcm_nsexception_getAPI()
+sentrycrashcm_nsexception_getAPI(void)
 {
     static SentryCrashMonitorAPI api = { .setEnabled = setEnabled, .isEnabled = isEnabled };
     return &api;

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Signal.c
@@ -120,7 +120,7 @@ handleSignal(int sigNum, siginfo_t *signalInfo, void *userContext)
 // ============================================================================
 
 static bool
-installSignalHandler()
+installSignalHandler(void)
 {
     SentryCrashLOG_DEBUG("Installing signal handler.");
 
@@ -230,7 +230,7 @@ setEnabled(bool isEnabled)
 }
 
 static bool
-isEnabled()
+isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -247,7 +247,7 @@ addContextualInfoToEvent(struct SentryCrash_MonitorContext *eventContext)
 #endif
 
 SentryCrashMonitorAPI *
-sentrycrashcm_signal_getAPI()
+sentrycrashcm_signal_getAPI(void)
 {
     static SentryCrashMonitorAPI api = {
 #if SentryCrashCRASH_HAS_SIGNAL

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_System.m
@@ -239,7 +239,7 @@ uuidBytesToString(const uint8_t *uuidBytes)
  * @return Executable path.
  */
 static NSString *
-getExecutablePath()
+getExecutablePath(void)
 {
     NSBundle *mainBundle = [NSBundle mainBundle];
     NSDictionary *infoDict = [mainBundle infoDictionary];
@@ -253,7 +253,7 @@ getExecutablePath()
  * @return The UUID.
  */
 static const char *
-getAppUUID()
+getAppUUID(void)
 {
     const char *result = nil;
 
@@ -311,7 +311,7 @@ getCPUArchForCPUType(cpu_type_t cpuType, cpu_subtype_t subType)
 }
 
 static const char *
-getCurrentCPUArch()
+getCurrentCPUArch(void)
 {
     const char *result = getCPUArchForCPUType(sentrycrashsysctl_int32ForName("hw.cputype"),
         sentrycrashsysctl_int32ForName("hw.cpusubtype"));
@@ -327,7 +327,7 @@ getCurrentCPUArch()
  * @return YES if the device is jailbroken.
  */
 static bool
-isJailbroken()
+isJailbroken(void)
 {
     return sentrycrashdl_imageNamed("MobileSubstrate", false) != UINT32_MAX;
 }
@@ -337,7 +337,7 @@ isJailbroken()
  * @return YES if the app was built in debug mode.
  */
 static bool
-isDebugBuild()
+isDebugBuild(void)
 {
 #ifdef DEBUG
     return YES;
@@ -351,7 +351,7 @@ isDebugBuild()
  * @return YES if this is a simulator build.
  */
 static bool
-isSimulatorBuild()
+isSimulatorBuild(void)
 {
 #if TARGET_OS_SIMULATOR
     return YES;
@@ -371,7 +371,7 @@ sentrycrash_isSimulatorBuild(void)
  * @return App Store receipt for iOS, nil otherwise.
  */
 static NSString *
-getReceiptUrlPath()
+getReceiptUrlPath(void)
 {
 #if SentryCrashCRASH_HOST_IOS
     return [NSBundle mainBundle].appStoreReceiptURL.path;
@@ -386,7 +386,7 @@ getReceiptUrlPath()
  * @return The stringified hex representation of the hash for this device + app.
  */
 static const char *
-getDeviceAndAppHash()
+getDeviceAndAppHash(void)
 {
     NSMutableData *data = nil;
 
@@ -434,7 +434,7 @@ getDeviceAndAppHash()
  * @return YES if this is a testing build.
  */
 static bool
-isTestBuild()
+isTestBuild(void)
 {
     return [getReceiptUrlPath().lastPathComponent isEqualToString:@"sandboxReceipt"];
 }
@@ -445,7 +445,7 @@ isTestBuild()
  * @return YES if there is an app store receipt.
  */
 static bool
-hasAppStoreReceipt()
+hasAppStoreReceipt(void)
 {
     NSString *receiptPath = getReceiptUrlPath();
     if (receiptPath == nil) {
@@ -461,13 +461,13 @@ hasAppStoreReceipt()
  * Check if the app has an embdded.mobileprovision file in the bundle.
  */
 static bool
-hasEmbeddedMobileProvision()
+hasEmbeddedMobileProvision(void)
 {
     return [[NSBundle mainBundle] pathForResource:@"embedded" ofType:@"mobileprovision"] != nil;
 }
 
 static const char *
-getBuildType()
+getBuildType(void)
 {
     if (isSimulatorBuild()) {
         return "simulator";
@@ -488,7 +488,7 @@ getBuildType()
 }
 
 static bytes
-getTotalStorageSize()
+getTotalStorageSize(void)
 {
     NSNumber *storageSize = [[[NSFileManager defaultManager]
         attributesOfFileSystemForPath:NSHomeDirectory()
@@ -497,7 +497,7 @@ getTotalStorageSize()
 }
 
 static bytes
-getFreeStorageSize()
+getFreeStorageSize(void)
 {
     NSNumber *storageSize = [[[NSFileManager defaultManager]
         attributesOfFileSystemForPath:NSHomeDirectory()
@@ -516,7 +516,7 @@ sentrycrashcm_system_freestorage_size(void)
 // ============================================================================
 
 static void
-initialize()
+initialize(void)
 {
     static bool isInitialized = false;
     if (!isInitialized) {
@@ -604,7 +604,7 @@ setEnabled(bool isEnabled)
 }
 
 static bool
-isEnabled()
+isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -649,7 +649,7 @@ addContextualInfoToEvent(SentryCrash_MonitorContext *eventContext)
 }
 
 SentryCrashMonitorAPI *
-sentrycrashcm_system_getAPI()
+sentrycrashcm_system_getAPI(void)
 {
     static SentryCrashMonitorAPI api = { .setEnabled = setEnabled,
         .isEnabled = isEnabled,

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_User.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_User.c
@@ -95,13 +95,13 @@ setEnabled(bool isEnabled)
 }
 
 static bool
-isEnabled()
+isEnabled(void)
 {
     return g_isEnabled;
 }
 
 SentryCrashMonitorAPI *
-sentrycrashcm_user_getAPI()
+sentrycrashcm_user_getAPI(void)
 {
     static SentryCrashMonitorAPI api = { .setEnabled = setEnabled, .isEnabled = isEnabled };
     return &api;

--- a/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Zombie.c
+++ b/Sources/SentryCrash/Recording/Monitors/SentryCrashMonitor_Zombie.c
@@ -136,7 +136,7 @@ handleDealloc(const void *self)
         fn f = (fn)g_originalDealloc_##CLASS;                                                      \
         f(self, _cmd);                                                                             \
     }                                                                                              \
-    static void installDealloc_##CLASS()                                                           \
+    static void installDealloc_##CLASS(void)                                                       \
     {                                                                                              \
         Method method                                                                              \
             = class_getInstanceMethod(objc_getClass(#CLASS), sel_registerName("dealloc"));         \
@@ -154,7 +154,7 @@ CREATE_ZOMBIE_HANDLER_INSTALLER(NSObject)
 CREATE_ZOMBIE_HANDLER_INSTALLER(NSProxy)
 
 static void
-install()
+install(void)
 {
     unsigned cacheSize = CACHE_SIZE;
     g_zombieHashMask = cacheSize - 1;
@@ -222,7 +222,7 @@ setEnabled(bool isEnabled)
 }
 
 static bool
-isEnabled()
+isEnabled(void)
 {
     return g_isEnabled;
 }
@@ -238,7 +238,7 @@ addContextualInfoToEvent(SentryCrash_MonitorContext *eventContext)
 }
 
 SentryCrashMonitorAPI *
-sentrycrashcm_zombie_getAPI()
+sentrycrashcm_zombie_getAPI(void)
 {
     static SentryCrashMonitorAPI api = { .setEnabled = setEnabled,
         .isEnabled = isEnabled,

--- a/Sources/SentryCrash/Recording/SentryCrash.m
+++ b/Sources/SentryCrash/Recording/SentryCrash.m
@@ -59,7 +59,7 @@ SentryCrash ()
 @end
 
 static NSString *
-getBundleName()
+getBundleName(void)
 {
     NSString *bundleName = [[[NSBundle mainBundle] infoDictionary] objectForKey:@"CFBundleName"];
     if (bundleName == nil) {
@@ -69,7 +69,7 @@ getBundleName()
 }
 
 static NSString *
-getBasePath()
+getBasePath(void)
 {
     NSArray *directories
         = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);

--- a/Sources/SentryCrash/Recording/SentryCrashC.c
+++ b/Sources/SentryCrash/Recording/SentryCrashC.c
@@ -274,7 +274,7 @@ sentrycrash_notifyAppCrash(void)
 }
 
 int
-sentrycrash_getReportCount()
+sentrycrash_getReportCount(void)
 {
     return sentrycrashcrs_getReportCount();
 }
@@ -315,7 +315,7 @@ sentrycrash_addUserReport(const char *report, int reportLength)
 }
 
 void
-sentrycrash_deleteAllReports()
+sentrycrash_deleteAllReports(void)
 {
     sentrycrashcrs_deleteAllReports();
 }
@@ -327,13 +327,13 @@ sentrycrash_deleteReportWithID(int64_t reportID)
 }
 
 bool
-sentrycrash_hasSaveScreenshotCallback()
+sentrycrash_hasSaveScreenshotCallback(void)
 {
     return g_saveScreenShot != NULL;
 }
 
 bool
-sentrycrash_hasSaveViewHierarchyCallback()
+sentrycrash_hasSaveViewHierarchyCallback(void)
 {
     return g_saveViewHierarchy != NULL;
 }

--- a/Sources/SentryCrash/Recording/SentryCrashCachedData.c
+++ b/Sources/SentryCrash/Recording/SentryCrashCachedData.c
@@ -53,7 +53,7 @@ static _Atomic(int) g_semaphoreCount;
 static bool g_hasThreadStarted = false;
 
 static void
-updateThreadList()
+updateThreadList(void)
 {
     const task_t thisTask = mach_task_self();
     int oldThreadsCount = g_allThreadsCount;
@@ -166,7 +166,7 @@ sentrycrashccd_init(int pollingIntervalInSeconds)
 }
 
 void
-sentrycrashccd_close()
+sentrycrashccd_close(void)
 {
     if (g_hasThreadStarted == true) {
         g_hasThreadStarted = false;
@@ -175,7 +175,7 @@ sentrycrashccd_close()
 }
 
 void
-sentrycrashccd_freeze()
+sentrycrashccd_freeze(void)
 {
     if (g_semaphoreCount++ <= 0) {
         // Sleep just in case the cached data thread is in the middle of an
@@ -185,7 +185,7 @@ sentrycrashccd_freeze()
 }
 
 void
-sentrycrashccd_unfreeze()
+sentrycrashccd_unfreeze(void)
 {
     if (--g_semaphoreCount < 0) {
         // Handle extra calls to unfreeze somewhat gracefully.

--- a/Sources/SentryCrash/Recording/SentryCrashReportStore.c
+++ b/Sources/SentryCrash/Recording/SentryCrashReportStore.c
@@ -59,7 +59,7 @@ compareInt64(const void *a, const void *b)
 }
 
 static inline int64_t
-getNextUniqueID()
+getNextUniqueID(void)
 {
     return g_nextUniqueIDHigh + g_nextUniqueIDLow++;
 }
@@ -97,7 +97,7 @@ getReportIDFromFilePath(const char *filepath)
 }
 
 static int
-getReportCount()
+getReportCount(void)
 {
     int count = 0;
     DIR *dir = opendir(g_reportsPath);
@@ -147,7 +147,7 @@ done:
 }
 
 static void
-pruneReports()
+pruneReports(void)
 {
     int reportCount = getReportCount();
     if (reportCount > g_maxReportCount) {
@@ -161,7 +161,7 @@ pruneReports()
 }
 
 static void
-initializeIDs()
+initializeIDs(void)
 {
     time_t rawTime;
     time(&rawTime);
@@ -198,7 +198,7 @@ sentrycrashcrs_getNextCrashReportPath(char *crashReportPathBuffer)
 }
 
 int
-sentrycrashcrs_getReportCount()
+sentrycrashcrs_getReportCount(void)
 {
     pthread_mutex_lock(&g_mutex);
     int count = getReportCount();
@@ -279,7 +279,7 @@ done:
 }
 
 void
-sentrycrashcrs_deleteAllReports()
+sentrycrashcrs_deleteAllReports(void)
 {
     pthread_mutex_lock(&g_mutex);
     sentrycrashfu_deleteContentsOfPath(g_reportsPath);

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashDynamicLinker.c
@@ -334,7 +334,7 @@ getCrashInfo(const struct mach_header *header, SentryCrashBinaryImage *buffer)
 }
 
 int
-sentrycrashdl_imageCount()
+sentrycrashdl_imageCount(void)
 {
     return (int)_dyld_image_count();
 }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashLogger.c
@@ -232,7 +232,7 @@ sentrycrashlog_setLogFilename(const char *filename, bool overwrite)
 #endif
 
 bool
-sentrycrashlog_clearLogFile()
+sentrycrashlog_clearLogFile(void)
 {
     return sentrycrashlog_setLogFilename(g_logFilename, true);
 }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashMachineContext.c
@@ -95,7 +95,7 @@ getThreadList(SentryCrashMachineContext *context)
 }
 
 int
-sentrycrashmc_contextSize()
+sentrycrashmc_contextSize(void)
 {
     return sizeof(SentryCrashMachineContext);
 }

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashSysCtl.c
@@ -192,7 +192,7 @@ sentrycrashsysctl_timevalForName(const char *const name)
 }
 
 struct timeval
-sentrycrashsysctl_currentProcessStartTime()
+sentrycrashsysctl_currentProcessStartTime(void)
 {
     size_t len = 4;
     int mib[len];

--- a/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryCrashThread.c
@@ -38,7 +38,7 @@
 #include <sys/sysctl.h>
 
 SentryCrashThread
-sentrycrashthread_self()
+sentrycrashthread_self(void)
 {
     thread_t thread_self = mach_thread_self();
     mach_port_deallocate(mach_task_self(), thread_self);

--- a/Sources/SentryCrash/Recording/Tools/SentryHook.c
+++ b/Sources/SentryCrash/Recording/Tools/SentryHook.c
@@ -294,7 +294,7 @@ sentrycrash_install_async_hooks(void)
 }
 
 void
-sentrycrash_deactivate_async_hooks()
+sentrycrash_deactivate_async_hooks(void)
 {
     // Instead of reverting the rebinding (which is not really possible), we rather
     // deactivate the hooks. They still exist, and still get called, but they will just

--- a/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
+++ b/Tests/SentryTests/Protocol/SentryBreadcrumbTests.swift
@@ -19,7 +19,7 @@ class SentryBreadcrumbTests: XCTestCase {
             breadcrumb.category = category
             breadcrumb.type = "user"
             breadcrumb.message = "Click something"
-            breadcrumb.data = ["some": ["data": "data", "date": date]]
+            breadcrumb.data = ["some": ["data": "data", "date": date] as [String: Any]]
         }
         
         var dateAs8601String: String {

--- a/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
+++ b/Tests/SentryTests/Protocol/SentrySdkInfoTests.swift
@@ -43,7 +43,7 @@ class SentrySdkInfoTests: XCTestCase {
     }
     
     func testInitWithDict_AllNil() {
-        let dict = ["sdk": [ "name": nil, "version": nil]]
+        let dict = ["sdk": [ "name": nil, "version": nil] as [String: Any?]]
         
         assertEmptySdkInfo(actual: SentrySdkInfo(dict: dict))
     }

--- a/Tests/SentryTests/Protocol/TestData.swift
+++ b/Tests/SentryTests/Protocol/TestData.swift
@@ -12,7 +12,7 @@ class TestData {
         }
     }
     static let sdk = ["name": SentryMeta.sdkName, "version": SentryMeta.versionString]
-    static let context = ["context": ["c": "a", "date": timestamp]]
+    static let context = ["context": ["c": "a", "date": timestamp] as [String: Any]]
     
     static var crumb: Breadcrumb {
         let crumb = Breadcrumb()
@@ -20,7 +20,7 @@ class TestData {
         crumb.timestamp = timestamp
         crumb.type = "user"
         crumb.message = "Clicked something"
-        crumb.data = ["some": ["data": "data", "date": timestamp]]
+        crumb.data = ["some": ["data": "data", "date": timestamp] as [String: Any]]
         return crumb
     }
     
@@ -60,7 +60,7 @@ class TestData {
         user.username = "user123"
         user.ipAddress = "127.0.0.1"
         user.segment = "segmentA"
-        user.data = ["some": ["data": "data", "date": timestamp]]
+        user.data = ["some": ["data": "data", "date": timestamp] as [String: Any]]
         
         return user
     }

--- a/Tests/SentryTests/SentryScopeSwiftTests.swift
+++ b/Tests/SentryTests/SentryScopeSwiftTests.swift
@@ -29,14 +29,14 @@ class SentryScopeSwiftTests: XCTestCase {
             user.email = "user@sentry.io"
             user.username = "user123"
             user.ipAddress = ipAddress
-            user.data = ["some": ["data": "data", "date": date]]
+            user.data = ["some": ["data": "data", "date": date] as [String: Any]]
             
             breadcrumb = Breadcrumb()
             breadcrumb.level = SentryLevel.info
             breadcrumb.timestamp = date
             breadcrumb.type = "user"
             breadcrumb.message = "Clicked something"
-            breadcrumb.data = ["some": ["data": "data", "date": date]]
+            breadcrumb.data = ["some": ["data": "data", "date": date] as [String: Any]]
             
             scope = Scope(maxBreadcrumbs: maxBreadcrumbs)
             scope.setUser(user)


### PR DESCRIPTION
This reapplies #1 to our branch of the 7.27.1 release. It's a mostly-identical cherrypick, except that:
* `Tests/SentryTests/Helper/SentryDeviceTests.mm` doesn't exist in this version
* There were a few additional instances of functions without a prototype